### PR TITLE
Update enclave to capture host OCALL results

### DIFF
--- a/enclave/enclave.cpp
+++ b/enclave/enclave.cpp
@@ -27,17 +27,17 @@ oe_result_t initialize_enclave_ml_context(
     }
 
     oe_result_t ocall_mechanism_status;
-    oe_result_t ocall_actual_retval;
+    oe_result_t host_return_value = OE_FAILURE;
     uint64_t host_session_handle = 0;
 
     ocall_mechanism_status = ocall_onnx_load_model(
-        &ocall_actual_retval,
+        &host_return_value,
         &host_session_handle,
         model_data,
         model_size);
 
     if (ocall_mechanism_status != OE_OK) return ocall_mechanism_status;
-    if (ocall_actual_retval != OE_OK) return ocall_actual_retval;
+    if (host_return_value != OE_OK) return host_return_value;
     if (host_session_handle == 0) return OE_UNEXPECTED;
 
     enclave_ml_session_t new_session = {host_session_handle};
@@ -67,10 +67,10 @@ oe_result_t enclave_infer(
 
     enclave_ml_session_t* session = &it->second;
     oe_result_t ocall_mechanism_status;
-    oe_result_t ocall_actual_retval;
+    oe_result_t host_return_value = OE_FAILURE;
 
     ocall_mechanism_status = ocall_onnx_run_inference(
-        &ocall_actual_retval,
+        &host_return_value,
         session->host_onnx_session_handle,
         input_data,
         input_data_byte_size,
@@ -79,7 +79,7 @@ oe_result_t enclave_infer(
         actual_output_size_bytes_out);
 
     if (ocall_mechanism_status != OE_OK) return ocall_mechanism_status;
-    if (ocall_actual_retval != OE_OK) return ocall_actual_retval;
+    if (host_return_value != OE_OK) return host_return_value;
 
     return OE_OK;
 }
@@ -96,16 +96,16 @@ oe_result_t terminate_enclave_ml_context(uint64_t enclave_session_handle) {
 
     enclave_ml_session_t* session = &it->second;
     oe_result_t ocall_mechanism_status;
-    oe_result_t ocall_actual_retval;
+    oe_result_t host_return_value = OE_FAILURE;
     
     ocall_mechanism_status = ocall_onnx_release_session(
-        &ocall_actual_retval,
+        &host_return_value,
         session->host_onnx_session_handle);
 
     g_enclave_sessions.erase(it);
 
     if (ocall_mechanism_status != OE_OK) return ocall_mechanism_status;
-    if (ocall_actual_retval != OE_OK) return ocall_actual_retval;
+    if (host_return_value != OE_OK) return host_return_value;
     
     return OE_OK;
 }


### PR DESCRIPTION
## Summary
- store the host OCALL return value when loading models, running inference, and releasing sessions
- verify the host-returned value before using output data

## Testing
- `cmake .. -DONNXRUNTIME_ROOT_DIR=/opt/onnxruntime -DCMAKE_BUILD_TYPE=Debug` *(fails: Could not find OpenEnclaveConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_b_684aed881d1c832a9a22eb81e5f73c77