### PR TITLE
Rename ocall functions to ggml

### DIFF
--- a/build/edl_generated/enclave_t.c
+++ b/build/edl_generated/enclave_t.c
@@ -757,9 +757,9 @@ size_t oe_ecalls_table_size = OE_COUNTOF(oe_ecalls_table);
 /**** Untrusted function IDs. ****/
 enum
 {
-    enclave_fcn_id_ocall_onnx_load_model = 0,
-    enclave_fcn_id_ocall_onnx_run_inference = 1,
-    enclave_fcn_id_ocall_onnx_release_session = 2,
+    enclave_fcn_id_ocall_ggml_load_model = 0,
+    enclave_fcn_id_ocall_ggml_run_inference = 1,
+    enclave_fcn_id_ocall_ggml_release_session = 2,
     enclave_fcn_id_oe_get_supported_attester_format_ids_ocall = 3,
     enclave_fcn_id_oe_get_qetarget_info_ocall = 4,
     enclave_fcn_id_oe_get_quote_ocall = 5,
@@ -781,7 +781,7 @@ enum
 };
 
 /**** OCALL marshalling structs. ****/
-typedef struct _ocall_onnx_load_model_args_t
+typedef struct _ocall_ggml_load_model_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -792,9 +792,9 @@ typedef struct _ocall_onnx_load_model_args_t
     uint64_t* host_session_handle;
     unsigned char* model_data;
     size_t model_data_len;
-} ocall_onnx_load_model_args_t;
+} ocall_ggml_load_model_args_t;
 
-typedef struct _ocall_onnx_run_inference_args_t
+typedef struct _ocall_ggml_run_inference_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -808,9 +808,9 @@ typedef struct _ocall_onnx_run_inference_args_t
     void* output_data;
     size_t output_buf_len;
     size_t* actual_output_len;
-} ocall_onnx_run_inference_args_t;
+} ocall_ggml_run_inference_args_t;
 
-typedef struct _ocall_onnx_release_session_args_t
+typedef struct _ocall_ggml_release_session_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -819,7 +819,7 @@ typedef struct _ocall_onnx_release_session_args_t
     oe_result_t* ocall_host_ret;
     oe_result_t* host_return_value;
     uint64_t host_session_handle;
-} ocall_onnx_release_session_args_t;
+} ocall_ggml_release_session_args_t;
 
 typedef struct _oe_get_supported_attester_format_ids_ocall_args_t
 {
@@ -1083,7 +1083,7 @@ typedef struct _oe_write_ocall_args_t
 
 /**** OCALL function wrappers. ****/
 
-oe_result_t ocall_onnx_load_model(
+oe_result_t ocall_ggml_load_model(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
@@ -1099,7 +1099,7 @@ oe_result_t ocall_onnx_load_model(
         return oe_get_enclave_status();
 
     /* Marshalling struct. */
-    ocall_onnx_load_model_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
+    ocall_ggml_load_model_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
     /* Marshalling buffer and sizes. */
     size_t _input_buffer_size = 0;
     size_t _output_buffer_size = 0;
@@ -1121,12 +1121,12 @@ oe_result_t ocall_onnx_load_model(
     _args.model_data_len = model_data_len;
 
     /* Compute input buffer size. Include in and in-out parameters. */
-    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_onnx_load_model_args_t));
+    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_ggml_load_model_args_t));
     if (model_data)
         OE_ADD_ARG_SIZE(_input_buffer_size, 1, _args.model_data_len);
     
     /* Compute output buffer size. Include out and in-out parameters. */
-    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_onnx_load_model_args_t));
+    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_ggml_load_model_args_t));
     if (ocall_host_ret)
         OE_ADD_ARG_SIZE(_output_buffer_size, 1, sizeof(oe_result_t));
     if (host_return_value)
@@ -1147,7 +1147,7 @@ oe_result_t ocall_onnx_load_model(
     }
     
     /* Serialize buffer inputs (in and in-out parameters). */
-    _pargs_in = (ocall_onnx_load_model_args_t*)_input_buffer;
+    _pargs_in = (ocall_ggml_load_model_args_t*)_input_buffer;
     OE_ADD_SIZE(_input_buffer_offset, sizeof(*_pargs_in));
     if (model_data)
         OE_WRITE_IN_PARAM_WITH_BARRIER(model_data, 1, _args.model_data_len, unsigned char*);
@@ -1157,7 +1157,7 @@ oe_result_t ocall_onnx_load_model(
 
     /* Call host function. */
     if ((_result = oe_call_host_function(
-             enclave_fcn_id_ocall_onnx_load_model,
+             enclave_fcn_id_ocall_ggml_load_model,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,
@@ -1195,7 +1195,7 @@ oe_result_t ocall_onnx_load_model(
     }
 
     /* Setup output arg struct pointer. */
-    _pargs_out = (ocall_onnx_load_model_args_t*)_output_buffer;
+    _pargs_out = (ocall_ggml_load_model_args_t*)_output_buffer;
     OE_ADD_SIZE(_output_buffer_offset, sizeof(*_pargs_out));
 
     /* Check if the call succeeded. */
@@ -1224,7 +1224,7 @@ done:
     return _result;
 }
 
-oe_result_t ocall_onnx_run_inference(
+oe_result_t ocall_ggml_run_inference(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
@@ -1243,7 +1243,7 @@ oe_result_t ocall_onnx_run_inference(
         return oe_get_enclave_status();
 
     /* Marshalling struct. */
-    ocall_onnx_run_inference_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
+    ocall_ggml_run_inference_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
     /* Marshalling buffer and sizes. */
     size_t _input_buffer_size = 0;
     size_t _output_buffer_size = 0;
@@ -1268,12 +1268,12 @@ oe_result_t ocall_onnx_run_inference(
     _args.actual_output_len = (size_t*)actual_output_len;
 
     /* Compute input buffer size. Include in and in-out parameters. */
-    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_onnx_run_inference_args_t));
+    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_ggml_run_inference_args_t));
     if (input_data)
         OE_ADD_ARG_SIZE(_input_buffer_size, 1, _args.input_len);
     
     /* Compute output buffer size. Include out and in-out parameters. */
-    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_onnx_run_inference_args_t));
+    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_ggml_run_inference_args_t));
     if (ocall_host_ret)
         OE_ADD_ARG_SIZE(_output_buffer_size, 1, sizeof(oe_result_t));
     if (host_return_value)
@@ -1296,7 +1296,7 @@ oe_result_t ocall_onnx_run_inference(
     }
     
     /* Serialize buffer inputs (in and in-out parameters). */
-    _pargs_in = (ocall_onnx_run_inference_args_t*)_input_buffer;
+    _pargs_in = (ocall_ggml_run_inference_args_t*)_input_buffer;
     OE_ADD_SIZE(_input_buffer_offset, sizeof(*_pargs_in));
     if (input_data)
         OE_WRITE_IN_PARAM_WITH_BARRIER(input_data, 1, _args.input_len, void*);
@@ -1306,7 +1306,7 @@ oe_result_t ocall_onnx_run_inference(
 
     /* Call host function. */
     if ((_result = oe_call_host_function(
-             enclave_fcn_id_ocall_onnx_run_inference,
+             enclave_fcn_id_ocall_ggml_run_inference,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,
@@ -1344,7 +1344,7 @@ oe_result_t ocall_onnx_run_inference(
     }
 
     /* Setup output arg struct pointer. */
-    _pargs_out = (ocall_onnx_run_inference_args_t*)_output_buffer;
+    _pargs_out = (ocall_ggml_run_inference_args_t*)_output_buffer;
     OE_ADD_SIZE(_output_buffer_offset, sizeof(*_pargs_out));
 
     /* Check if the call succeeded. */
@@ -1374,7 +1374,7 @@ done:
     return _result;
 }
 
-oe_result_t ocall_onnx_release_session(
+oe_result_t ocall_ggml_release_session(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
@@ -1388,7 +1388,7 @@ oe_result_t ocall_onnx_release_session(
         return oe_get_enclave_status();
 
     /* Marshalling struct. */
-    ocall_onnx_release_session_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
+    ocall_ggml_release_session_args_t _args, *_pargs_in = NULL, *_pargs_out = NULL;
     /* Marshalling buffer and sizes. */
     size_t _input_buffer_size = 0;
     size_t _output_buffer_size = 0;
@@ -1408,11 +1408,11 @@ oe_result_t ocall_onnx_release_session(
     _args.host_session_handle = host_session_handle;
 
     /* Compute input buffer size. Include in and in-out parameters. */
-    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_onnx_release_session_args_t));
+    OE_ADD_SIZE(_input_buffer_size, sizeof(ocall_ggml_release_session_args_t));
     /* There were no corresponding parameters. */
     
     /* Compute output buffer size. Include out and in-out parameters. */
-    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_onnx_release_session_args_t));
+    OE_ADD_SIZE(_output_buffer_size, sizeof(ocall_ggml_release_session_args_t));
     if (ocall_host_ret)
         OE_ADD_ARG_SIZE(_output_buffer_size, 1, sizeof(oe_result_t));
     if (host_return_value)
@@ -1431,7 +1431,7 @@ oe_result_t ocall_onnx_release_session(
     }
     
     /* Serialize buffer inputs (in and in-out parameters). */
-    _pargs_in = (ocall_onnx_release_session_args_t*)_input_buffer;
+    _pargs_in = (ocall_ggml_release_session_args_t*)_input_buffer;
     OE_ADD_SIZE(_input_buffer_offset, sizeof(*_pargs_in));
     /* There were no in nor in-out parameters. */
     
@@ -1440,7 +1440,7 @@ oe_result_t ocall_onnx_release_session(
 
     /* Call host function. */
     if ((_result = oe_call_host_function(
-             enclave_fcn_id_ocall_onnx_release_session,
+             enclave_fcn_id_ocall_ggml_release_session,
              _input_buffer,
              _input_buffer_size,
              _output_buffer,
@@ -1478,7 +1478,7 @@ oe_result_t ocall_onnx_release_session(
     }
 
     /* Setup output arg struct pointer. */
-    _pargs_out = (ocall_onnx_release_session_args_t*)_output_buffer;
+    _pargs_out = (ocall_ggml_release_session_args_t*)_output_buffer;
     OE_ADD_SIZE(_output_buffer_offset, sizeof(*_pargs_out));
 
     /* Check if the call succeeded. */

--- a/build/edl_generated/enclave_t.h
+++ b/build/edl_generated/enclave_t.h
@@ -55,7 +55,7 @@ void oe_log_init_ecall(
     uint32_t log_level);
 
 /**** OCALL prototypes. ****/
-oe_result_t ocall_onnx_load_model(
+oe_result_t ocall_ggml_load_model(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
@@ -63,7 +63,7 @@ oe_result_t ocall_onnx_load_model(
     const unsigned char* model_data,
     size_t model_data_len);
 
-oe_result_t ocall_onnx_run_inference(
+oe_result_t ocall_ggml_run_inference(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
@@ -74,7 +74,7 @@ oe_result_t ocall_onnx_run_inference(
     size_t output_buf_len,
     size_t* actual_output_len);
 
-oe_result_t ocall_onnx_release_session(
+oe_result_t ocall_ggml_release_session(
     oe_result_t* _retval,
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,

--- a/build/edl_generated/enclave_u.c
+++ b/build/edl_generated/enclave_u.c
@@ -1079,9 +1079,9 @@ OE_WEAK_ALIAS(enclave_oe_log_init_ecall, oe_log_init_ecall);
 /**** Untrusted function IDs. ****/
 enum
 {
-    enclave_fcn_id_ocall_onnx_load_model = 0,
-    enclave_fcn_id_ocall_onnx_run_inference = 1,
-    enclave_fcn_id_ocall_onnx_release_session = 2,
+    enclave_fcn_id_ocall_ggml_load_model = 0,
+    enclave_fcn_id_ocall_ggml_run_inference = 1,
+    enclave_fcn_id_ocall_ggml_release_session = 2,
     enclave_fcn_id_oe_get_supported_attester_format_ids_ocall = 3,
     enclave_fcn_id_oe_get_qetarget_info_ocall = 4,
     enclave_fcn_id_oe_get_quote_ocall = 5,
@@ -1103,7 +1103,7 @@ enum
 };
 
 /**** OCALL marshalling structs. ****/
-typedef struct _ocall_onnx_load_model_args_t
+typedef struct _ocall_ggml_load_model_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -1114,9 +1114,9 @@ typedef struct _ocall_onnx_load_model_args_t
     uint64_t* host_session_handle;
     unsigned char* model_data;
     size_t model_data_len;
-} ocall_onnx_load_model_args_t;
+} ocall_ggml_load_model_args_t;
 
-typedef struct _ocall_onnx_run_inference_args_t
+typedef struct _ocall_ggml_run_inference_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -1130,9 +1130,9 @@ typedef struct _ocall_onnx_run_inference_args_t
     void* output_data;
     size_t output_buf_len;
     size_t* actual_output_len;
-} ocall_onnx_run_inference_args_t;
+} ocall_ggml_run_inference_args_t;
 
-typedef struct _ocall_onnx_release_session_args_t
+typedef struct _ocall_ggml_release_session_args_t
 {
     oe_result_t oe_result;
     uint8_t* deepcopy_out_buffer;
@@ -1141,7 +1141,7 @@ typedef struct _ocall_onnx_release_session_args_t
     oe_result_t* ocall_host_ret;
     oe_result_t* host_return_value;
     uint64_t host_session_handle;
-} ocall_onnx_release_session_args_t;
+} ocall_ggml_release_session_args_t;
 
 typedef struct _oe_get_supported_attester_format_ids_ocall_args_t
 {
@@ -1405,7 +1405,7 @@ typedef struct _oe_write_ocall_args_t
 
 /**** OCALL functions. ****/
 
-static void ocall_ocall_onnx_load_model(
+static void ocall_ocall_ggml_load_model(
     uint8_t* input_buffer,
     size_t input_buffer_size,
     uint8_t* output_buffer,
@@ -1416,8 +1416,8 @@ static void ocall_ocall_onnx_load_model(
     OE_UNUSED(input_buffer_size);
 
     /* Prepare parameters. */
-    ocall_onnx_load_model_args_t* _pargs_in = (ocall_onnx_load_model_args_t*)input_buffer;
-    ocall_onnx_load_model_args_t* _pargs_out = (ocall_onnx_load_model_args_t*)output_buffer;
+    ocall_ggml_load_model_args_t* _pargs_in = (ocall_ggml_load_model_args_t*)input_buffer;
+    ocall_ggml_load_model_args_t* _pargs_out = (ocall_ggml_load_model_args_t*)output_buffer;
 
     size_t _input_buffer_offset = 0;
     size_t _output_buffer_offset = 0;
@@ -1447,7 +1447,7 @@ static void ocall_ocall_onnx_load_model(
         OE_SET_OUT_POINTER(host_session_handle, 1, sizeof(uint64_t), uint64_t*);
 
     /* Call user function. */
-    _pargs_out->oe_retval = ocall_onnx_load_model(
+    _pargs_out->oe_retval = ocall_ggml_load_model(
         _pargs_in->ocall_host_ret,
         _pargs_in->host_return_value,
         _pargs_in->host_session_handle,
@@ -1470,7 +1470,7 @@ done:
         _pargs_out->oe_result = _result;
 }
 
-static void ocall_ocall_onnx_run_inference(
+static void ocall_ocall_ggml_run_inference(
     uint8_t* input_buffer,
     size_t input_buffer_size,
     uint8_t* output_buffer,
@@ -1481,8 +1481,8 @@ static void ocall_ocall_onnx_run_inference(
     OE_UNUSED(input_buffer_size);
 
     /* Prepare parameters. */
-    ocall_onnx_run_inference_args_t* _pargs_in = (ocall_onnx_run_inference_args_t*)input_buffer;
-    ocall_onnx_run_inference_args_t* _pargs_out = (ocall_onnx_run_inference_args_t*)output_buffer;
+    ocall_ggml_run_inference_args_t* _pargs_in = (ocall_ggml_run_inference_args_t*)input_buffer;
+    ocall_ggml_run_inference_args_t* _pargs_out = (ocall_ggml_run_inference_args_t*)output_buffer;
 
     size_t _input_buffer_offset = 0;
     size_t _output_buffer_offset = 0;
@@ -1514,7 +1514,7 @@ static void ocall_ocall_onnx_run_inference(
         OE_SET_OUT_POINTER(actual_output_len, 1, sizeof(size_t), size_t*);
 
     /* Call user function. */
-    _pargs_out->oe_retval = ocall_onnx_run_inference(
+    _pargs_out->oe_retval = ocall_ggml_run_inference(
         _pargs_in->ocall_host_ret,
         _pargs_in->host_return_value,
         _pargs_in->host_session_handle,
@@ -1540,7 +1540,7 @@ done:
         _pargs_out->oe_result = _result;
 }
 
-static void ocall_ocall_onnx_release_session(
+static void ocall_ocall_ggml_release_session(
     uint8_t* input_buffer,
     size_t input_buffer_size,
     uint8_t* output_buffer,
@@ -1551,8 +1551,8 @@ static void ocall_ocall_onnx_release_session(
     OE_UNUSED(input_buffer_size);
 
     /* Prepare parameters. */
-    ocall_onnx_release_session_args_t* _pargs_in = (ocall_onnx_release_session_args_t*)input_buffer;
-    ocall_onnx_release_session_args_t* _pargs_out = (ocall_onnx_release_session_args_t*)output_buffer;
+    ocall_ggml_release_session_args_t* _pargs_in = (ocall_ggml_release_session_args_t*)input_buffer;
+    ocall_ggml_release_session_args_t* _pargs_out = (ocall_ggml_release_session_args_t*)output_buffer;
 
     size_t _input_buffer_offset = 0;
     size_t _output_buffer_offset = 0;
@@ -1579,7 +1579,7 @@ static void ocall_ocall_onnx_release_session(
         OE_SET_OUT_POINTER(host_return_value, 1, sizeof(oe_result_t), oe_result_t*);
 
     /* Call user function. */
-    _pargs_out->oe_retval = ocall_onnx_release_session(
+    _pargs_out->oe_retval = ocall_ggml_release_session(
         _pargs_in->ocall_host_ret,
         _pargs_in->host_return_value,
         _pargs_in->host_session_handle);
@@ -2869,9 +2869,9 @@ done:
 /**** OCALL function table. ****/
 
 static oe_ocall_func_t _enclave_ocall_function_table[] = {
-    (oe_ocall_func_t) ocall_ocall_onnx_load_model,
-    (oe_ocall_func_t) ocall_ocall_onnx_run_inference,
-    (oe_ocall_func_t) ocall_ocall_onnx_release_session,
+    (oe_ocall_func_t) ocall_ocall_ggml_load_model,
+    (oe_ocall_func_t) ocall_ocall_ggml_run_inference,
+    (oe_ocall_func_t) ocall_ocall_ggml_release_session,
     (oe_ocall_func_t) ocall_oe_get_supported_attester_format_ids_ocall,
     (oe_ocall_func_t) ocall_oe_get_qetarget_info_ocall,
     (oe_ocall_func_t) ocall_oe_get_quote_ocall,

--- a/build/edl_generated/enclave_u.h
+++ b/build/edl_generated/enclave_u.h
@@ -79,14 +79,14 @@ oe_result_t oe_log_init_ecall(
     uint32_t log_level);
 
 /**** OCALL prototypes. ****/
-oe_result_t ocall_onnx_load_model(
+oe_result_t ocall_ggml_load_model(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t* host_session_handle,
     const unsigned char* model_data,
     size_t model_data_len);
 
-oe_result_t ocall_onnx_run_inference(
+oe_result_t ocall_ggml_run_inference(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t host_session_handle,
@@ -96,7 +96,7 @@ oe_result_t ocall_onnx_run_inference(
     size_t output_buf_len,
     size_t* actual_output_len);
 
-oe_result_t ocall_onnx_release_session(
+oe_result_t ocall_ggml_release_session(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t host_session_handle);

--- a/common/enclave.edl
+++ b/common/enclave.edl
@@ -21,14 +21,14 @@ enclave {
     };
 
     untrusted {
-        oe_result_t ocall_onnx_load_model(
+        oe_result_t ocall_ggml_load_model(
             [out] oe_result_t* ocall_host_ret,
             [out] oe_result_t* host_return_value,
             [out] uint64_t* host_session_handle,
             [in, size=model_data_len] const unsigned char* model_data,
             size_t model_data_len);
 
-        oe_result_t ocall_onnx_run_inference(
+        oe_result_t ocall_ggml_run_inference(
             [out] oe_result_t* ocall_host_ret,
             [out] oe_result_t* host_return_value,
             uint64_t host_session_handle,
@@ -38,7 +38,7 @@ enclave {
             size_t output_buf_len,
             [out] size_t* actual_output_len);
 
-        oe_result_t ocall_onnx_release_session(
+        oe_result_t ocall_ggml_release_session(
             [out] oe_result_t* ocall_host_ret,
             [out] oe_result_t* host_return_value,
             uint64_t host_session_handle);

--- a/enclave/enclave.cpp
+++ b/enclave/enclave.cpp
@@ -32,7 +32,7 @@ oe_result_t initialize_enclave_ml_context(
     oe_result_t host_return_value = OE_FAILURE;
     uint64_t host_session_handle = 0;
 
-    ocall_status = ocall_onnx_load_model(
+    ocall_status = ocall_ggml_load_model(
         &ocall_retval,
         &ocall_host_ret,
         &host_return_value,
@@ -75,7 +75,7 @@ oe_result_t enclave_infer(
     oe_result_t ocall_host_ret = OE_FAILURE;
     oe_result_t host_return_value = OE_FAILURE;
 
-    ocall_status = ocall_onnx_run_inference(
+    ocall_status = ocall_ggml_run_inference(
         &ocall_retval,
         &ocall_host_ret,
         &host_return_value,
@@ -108,7 +108,7 @@ oe_result_t terminate_enclave_ml_context(uint64_t enclave_session_handle) {
     oe_result_t ocall_host_ret = OE_FAILURE;
     oe_result_t host_return_value = OE_FAILURE;
 
-    ocall_status = ocall_onnx_release_session(
+    ocall_status = ocall_ggml_release_session(
         &ocall_retval,
         &ocall_host_ret,
         &host_return_value,

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -56,7 +56,7 @@ std::vector<unsigned char> load_file_to_buffer(const std::string& filepath) {
     return buffer;
 }
 
-oe_result_t ocall_onnx_load_model(
+oe_result_t ocall_ggml_load_model(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t* host_session_handle_out,
@@ -82,14 +82,14 @@ oe_result_t ocall_onnx_load_model(
         *host_session_handle_out = current_host_handle;
         *host_return_value = OE_OK;
     } catch (const std::exception& e) {
-        std::cerr << "[Host] Exception in ocall_onnx_load_model: " << e.what() << std::endl;
+        std::cerr << "[Host] Exception in ocall_ggml_load_model: " << e.what() << std::endl;
         *host_return_value = OE_FAILURE;
     }
     *ocall_host_ret = OE_OK;
     return OE_OK;
 }
 
-oe_result_t ocall_onnx_run_inference(
+oe_result_t ocall_ggml_run_inference(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t host_session_handle,
@@ -155,7 +155,7 @@ oe_result_t ocall_onnx_run_inference(
     return OE_OK;
 }
 
-oe_result_t ocall_onnx_release_session(
+oe_result_t ocall_ggml_release_session(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t host_session_handle) {


### PR DESCRIPTION
## Summary
- rename ocall functions from `ocall_onnx_*` to `ocall_ggml_*`
- propagate name change in enclave and host code
- update generated EDL sources

## Testing
- `apt-get update -y`
- `apt-get install -y openenclave` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_684afc135b4c832a8d2facf3e58ad835