### PR TITLE
Improve host run target model checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ add_subdirectory(enclave)
 add_subdirectory(host)
 
 # --- Copy Model to Build Directory ---
+# The GGML model is not checked in. Developers should run
+# `scripts/download_deps.sh` before building or using the run targets.
 set(MODEL_SOURCE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/model/model.ggml)
 set(MODEL_BUILD_DIR ${CMAKE_BINARY_DIR}/model)
 set(MODEL_DEST_PATH ${MODEL_BUILD_DIR}/model.ggml)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -45,8 +45,10 @@ message(STATUS "[Host CMake] Model destination path for run target: ${MODEL_PATH
 
 # 2. Updated the 'run' target to work with the new stdin-based host
 # This now pipes a sample input string to the executable for testing.
+# NOTE: The GGML model must be downloaded via scripts/download_deps.sh
+# before attempting to run this target.
 add_custom_target(run
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${HOST_GGML_LIB_DIR}" bash -c "echo '3.14,-2.71' | ./${HOST_APP_NAME} ${MODEL_PATH_FOR_RUN_TARGET} ${SIGNED_ENCLAVE_FULL_PATH} --use-stdin"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${HOST_GGML_LIB_DIR}" bash -c "if [ ! -f \"${MODEL_PATH_FOR_RUN_TARGET}\" ]; then echo 'Model file missing at ${MODEL_PATH_FOR_RUN_TARGET}. Run scripts/download_deps.sh first.'; exit 1; fi; echo '3.14,-2.71' | ./${HOST_APP_NAME} ${MODEL_PATH_FOR_RUN_TARGET} ${SIGNED_ENCLAVE_FULL_PATH} --use-stdin"
     DEPENDS ${HOST_APP_NAME} ${ENCLAVE_TARGET_NAME}_signed
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} # Execute from build/host/
     COMMENT "Running ML PoC. Host: ./${HOST_APP_NAME}, Model: ${MODEL_PATH_FOR_RUN_TARGET}, Enclave: ${SIGNED_ENCLAVE_FULL_PATH}"
@@ -54,7 +56,7 @@ add_custom_target(run
 )
 
 add_custom_target(run_simulate
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${HOST_GGML_LIB_DIR}" bash -c "echo '3.14,-2.71' | ./${HOST_APP_NAME} ${MODEL_PATH_FOR_RUN_TARGET} ${SIGNED_ENCLAVE_FULL_PATH} --use-stdin --simulate"
+    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${HOST_GGML_LIB_DIR}" bash -c "if [ ! -f \"${MODEL_PATH_FOR_RUN_TARGET}\" ]; then echo 'Model file missing at ${MODEL_PATH_FOR_RUN_TARGET}. Run scripts/download_deps.sh first.'; exit 1; fi; echo '3.14,-2.71' | ./${HOST_APP_NAME} ${MODEL_PATH_FOR_RUN_TARGET} ${SIGNED_ENCLAVE_FULL_PATH} --use-stdin --simulate"
     DEPENDS ${HOST_APP_NAME} ${ENCLAVE_TARGET_NAME}_signed
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} # Execute from build/host/
     COMMENT "Running ML PoC in SIMULATION mode."


### PR DESCRIPTION
## Summary
- make `run` and `run_simulate` fail early if the model isn't present
- note the need to run `scripts/download_deps.sh` to get the model

## Testing
- `cmake ..` *(fails: OpenEnclave not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b0649900c832aa16f46c4066dcb87