### PR TITLE
Use download script for GGML model

### DIFF
--- a/scripts/download_assets.sh
+++ b/scripts/download_assets.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+GGML_DIR=/opt/ggml
+MODEL_DIR=/app/model
+MODEL_ID="distilbert-base-uncased-finetuned-sst-2-english"
+
+# Clone and build GGML
+mkdir -p "${GGML_DIR}"
+
+git clone --depth 1 https://github.com/ggerganov/ggml.git /tmp/ggml
+cd /tmp/ggml
+make
+mkdir -p ${GGML_DIR}/lib ${GGML_DIR}/include
+cp libggml.a ${GGML_DIR}/lib/
+cp -r include/ ${GGML_DIR}/include/
+
+# Convert Hugging Face model to GGML format
+cd examples/bert
+pip3 install --no-cache-dir transformers
+python3 convert-bert.py ${MODEL_ID} /tmp/model.ggml
+
+mkdir -p "${MODEL_DIR}"
+mv /tmp/model.ggml "${MODEL_DIR}/model.ggml"
+
+# cleanup
+test -d /tmp/ggml && rm -rf /tmp/ggml


### PR DESCRIPTION
## Summary
- add script to download GGML and convert DistilBERT
- invoke the download script during the build stage
- remove ONNX artifacts and adjust backend paths

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_b_684b064e2228832a9e650f5d89bf677d