### PR TITLE
Unify model path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ COPY tokenize_script.py .
 # Copy built artifacts from previous stages
 COPY --from=builder /app/build/host/ml_host_prod_go ./ml_host_prod_go
 COPY --from=builder /app/build/enclave/enclave_prod.signed.so ./enclave/enclave_prod.signed.so
-COPY --from=builder /app/distilbert-sst2-ggml/model.ggml ./model/model.ggml
+COPY --from=builder /app/model/bert.bin ./model/bert.bin
 COPY --from=builder /app/distilbert-sst2-ggml ./distilbert-sst2-ggml
 
 COPY --from=go-builder /main ./main

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ scripts/download_deps.sh
 After the script finishes you will have `model/bert.bin` and a
 `tokenizer/` directory containing the tokenizer configuration.
 
+All components—including the Go backend and Docker image—expect the
+model to reside at this unified path.
+
 ### Architecture Overview
 
 The project uses the [GGML](https://github.com/ggml-org/ggml) library to run a

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 
 Run `scripts/download_deps.sh` to fetch the GGML model and tokenizer. **Run this before invoking CMake** so that `model/bert.bin` is available during configuration.
 
+The backend and Docker setup now look for the model exclusively at this path.
+
 ## Build Steps
 
 ```bash

--- a/backend/main.go
+++ b/backend/main.go
@@ -85,7 +85,7 @@ func handleInference(w http.ResponseWriter, r *http.Request) {
 
 	// 2. Execute the C++ host application as a subprocess
 	hostAppPath := "./ml_host_prod_go"
-    modelPath := "./distilbert-sst2-ggml/model.ggml"
+    modelPath := "./model/bert.bin"
 	enclavePath := "./enclave/enclave_prod.signed.so"
 
 	cppCmd := exec.Command(hostAppPath, modelPath, enclavePath, "--use-stdin")


### PR DESCRIPTION
## Summary
- use `model/bert.bin` throughout
- copy the new model path into the Docker image
- document the unified location in READMEs

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_b_684b0f65b4f0832a882f40f7a63d8cc3