### PR TITLE
Clean build configuration and remove ONNX runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-onnx_env
 build/
 external/
 model/

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,7 @@
+This repository contains a Go backend, a C++ host/enclave using Open Enclave, and build scripts.  
+When adding new code or documentation:
+
+- Keep code formatting consistent with the surrounding files.
+- Run `scripts/download_deps.sh` before building to ensure external libraries are available.
+- The host application links against `bert.cpp` and `ggml`; avoid adding dependencies on extra dependencies.
+- Docker builds expect the model at `model/bert.bin` and tokenizer files under `tokenizer/`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,14 @@ get_target_property(GGML_LIBRARY ggml LOCATION)
 set(GLOBAL_GGML_INCLUDE_DIR ${GGML_SOURCE_DIR}/include CACHE INTERNAL "GGML include directory")
 set(GLOBAL_GGML_LIBRARY ${GGML_LIBRARY} CACHE INTERNAL "GGML library path")
 
+# --- Build bert.cpp from external directory ---
+set(BERTCPP_SOURCE_DIR ${EXTERNAL_DIR}/bert.cpp)
+if(NOT EXISTS "${BERTCPP_SOURCE_DIR}/CMakeLists.txt")
+    message(FATAL_ERROR "bert.cpp source not found at ${BERTCPP_SOURCE_DIR}. Did you run scripts/download_deps.sh?")
+endif()
+add_subdirectory(${BERTCPP_SOURCE_DIR} external_bertcpp_build)
+set(GLOBAL_BERTCPP_INCLUDE_DIR ${BERTCPP_SOURCE_DIR} CACHE INTERNAL "bert.cpp include directory")
+
 # --- EDL File Processing ---
 set(EDL_FILE ${CMAKE_CURRENT_SOURCE_DIR}/common/enclave.edl) 
 set(EDL_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/edl_generated)

--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -15,15 +15,18 @@ target_sources(${HOST_APP_NAME} PRIVATE
 
 target_link_libraries(${HOST_APP_NAME} PRIVATE
     openenclave::oehost
-    ggml
+    bert
     stdc++fs
 )
 
 # Include Directories for Host:
 if(GLOBAL_GGML_INCLUDE_DIR AND EXISTS "${GLOBAL_GGML_INCLUDE_DIR}")
     target_include_directories(${HOST_APP_NAME} PRIVATE ${GLOBAL_GGML_INCLUDE_DIR})
+endif()
+if(GLOBAL_BERTCPP_INCLUDE_DIR AND EXISTS "${GLOBAL_BERTCPP_INCLUDE_DIR}")
+    target_include_directories(${HOST_APP_NAME} PRIVATE ${GLOBAL_BERTCPP_INCLUDE_DIR})
 else()
-    message(FATAL_ERROR "Host (${HOST_APP_NAME}): GLOBAL_GGML_INCLUDE_DIR not properly set or found. GGML headers will not be found.")
+    message(FATAL_ERROR "Host (${HOST_APP_NAME}): GLOBAL_BERTCPP_INCLUDE_DIR not properly set or found. bert.cpp headers will not be found.")
 endif()
 
 add_dependencies(${HOST_APP_NAME} GenerateEDL)

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -1,4 +1,3 @@
-/* host/host.cpp - FINAL, COMPLETE, AND STABLE VERSION */
 #include <iostream>
 #include <vector>
 #include <fstream>
@@ -6,38 +5,26 @@
 #include <stdexcept>
 #include <filesystem>
 #include <map>
-#include <numeric>
 #include <sstream>
+#include <cstring>
 
 #include <openenclave/host.h>
 #include <openenclave/bits/result.h>
-#include <onnxruntime_c_api.h>
+#include "bert.h"
 #include "enclave_u.h"
 
-#define OE_HOST_CHECK(oe_result, function_name) \
+#define OE_HOST_CHECK(oe_result, fn) \
     do { \
         if ((oe_result) != OE_OK) { \
-            std::cerr << "[Host] Error: " << function_name << " failed with " \
-                      << oe_result_str(oe_result) << " (0x" << std::hex << oe_result << std::dec << ")" \
+            std::cerr << "[Host] " << fn << " failed with " << oe_result_str(oe_result) \
                       << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
-            throw std::runtime_error(std::string(function_name) + " failed."); \
+            throw std::runtime_error(std::string(fn) + " failed"); \
         } \
     } while (0)
 
-static const OrtApi* g_ort_api = nullptr;
-#define ORT_CHECK(ort_status) \
-    do { \
-        if ((ort_status) != nullptr) { \
-            const char* msg = g_ort_api->GetErrorMessage(ort_status); \
-            std::cerr << "[Host] ONNX Runtime Error: " << msg << std::endl; \
-            g_ort_api->ReleaseStatus(ort_status); \
-            throw std::runtime_error(std::string("ONNX Runtime failed: ") + msg); \
-        } \
-    } while (0)
-
-static OrtEnv* g_host_ort_env = nullptr;
-static std::map<uint64_t, OrtSession*> g_host_ggml_sessions;
-static uint64_t g_next_host_session_handle = 1;
+static std::map<uint64_t, bert_ctx*> g_sessions;
+static uint64_t g_next_session_handle = 1;
+static std::string g_model_path;
 
 std::vector<unsigned char> load_file_to_buffer(const std::string& filepath) {
     if (!std::filesystem::exists(filepath)) {
@@ -60,32 +47,25 @@ oe_result_t ocall_ggml_load_model(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
     uint64_t* host_session_handle_out,
-    const unsigned char* model_data,
-    size_t model_data_len) {
-    if (!ocall_host_ret || !host_return_value || !g_ort_api || !g_host_ort_env || !host_session_handle_out || !model_data || model_data_len == 0)
+    const unsigned char* /*model_data*/,
+    size_t /*model_data_len*/)
+{
+    if (!ocall_host_ret || !host_return_value || !host_session_handle_out)
         return OE_INVALID_PARAMETER;
-    *ocall_host_ret = OE_FAILURE;
-    *host_return_value = OE_FAILURE;
-    try {
-        *host_session_handle_out = 0;
-        OrtSessionOptions* session_options = nullptr;
-        ORT_CHECK(g_ort_api->CreateSessionOptions(&session_options));
-        ORT_CHECK(g_ort_api->DisableMemPattern(session_options));
-        ORT_CHECK(g_ort_api->DisablePerSessionThreads(session_options));
-        ORT_CHECK(g_ort_api->SetIntraOpNumThreads(session_options, 1));
-        ORT_CHECK(g_ort_api->SetInterOpNumThreads(session_options, 1));
-        OrtSession* session = nullptr;
-        ORT_CHECK(g_ort_api->CreateSessionFromArray(g_host_ort_env, model_data, model_data_len, session_options, &session));
-        if (session_options) g_ort_api->ReleaseSessionOptions(session_options);
-        uint64_t current_host_handle = g_next_host_session_handle++;
-        g_host_ggml_sessions[current_host_handle] = session;
-        *host_session_handle_out = current_host_handle;
-        *host_return_value = OE_OK;
-    } catch (const std::exception& e) {
-        std::cerr << "[Host] Exception in ocall_ggml_load_model: " << e.what() << std::endl;
-        *host_return_value = OE_FAILURE;
-    }
+
     *ocall_host_ret = OE_OK;
+    *host_return_value = OE_FAILURE;
+    *host_session_handle_out = 0;
+
+    bert_ctx* ctx = bert_load_from_file(g_model_path.c_str(), true);
+    if (!ctx)
+        return OE_OK;
+
+    bert_allocate_buffers(ctx, bert_n_max_tokens(ctx), 1);
+    uint64_t handle = g_next_session_handle++;
+    g_sessions[handle] = ctx;
+    *host_session_handle_out = handle;
+    *host_return_value = OE_OK;
     return OE_OK;
 }
 
@@ -97,93 +77,77 @@ oe_result_t ocall_ggml_run_inference(
     size_t input_len_bytes,
     void* output_data_to_enclave,
     size_t output_buf_len_bytes,
-    size_t* actual_output_len_bytes_out) {
-    if (!ocall_host_ret || !host_return_value) return OE_INVALID_PARAMETER;
-    *ocall_host_ret = OE_FAILURE;
-    *host_return_value = OE_FAILURE;
-    try {
-        auto it = g_host_ggml_sessions.find(host_session_handle);
-        if (it == g_host_ggml_sessions.end()) {
-            *host_return_value = OE_NOT_FOUND;
-            *ocall_host_ret = OE_OK;
-            return OE_OK;
-        }
-        OrtSession* session = it->second;
-        const char* input_names[] = {"input_ids", "attention_mask"};
-        const char* output_names[] = {"logits"};
-        size_t num_tokens = input_len_bytes / sizeof(int64_t);
-        std::vector<int64_t> local_input_ids(num_tokens);
-        memcpy(local_input_ids.data(), input_data_from_enclave, input_len_bytes);
-        std::vector<int64_t> attention_mask_data(num_tokens, 1);
-        std::vector<int64_t> input_shape = {1, (int64_t)num_tokens};
-        OrtMemoryInfo* memory_info;
-        ORT_CHECK(g_ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &memory_info));
-        OrtValue* input_ids_tensor = nullptr;
-        ORT_CHECK(g_ort_api->CreateTensorWithDataAsOrtValue(
-            memory_info, local_input_ids.data(), input_len_bytes,
-            input_shape.data(), input_shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &input_ids_tensor));
-        OrtValue* attention_mask_tensor = nullptr;
-        ORT_CHECK(g_ort_api->CreateTensorWithDataAsOrtValue(
-            memory_info, attention_mask_data.data(), attention_mask_data.size() * sizeof(int64_t),
-            input_shape.data(), input_shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &attention_mask_tensor));
-        std::vector<OrtValue*> input_tensors = {input_ids_tensor, attention_mask_tensor};
-        OrtValue* output_tensor = nullptr;
-        ORT_CHECK(g_ort_api->Run(session, nullptr, input_names, input_tensors.data(), 2, output_names, 1, &output_tensor));
-        OrtTensorTypeAndShapeInfo* output_info;
-        ORT_CHECK(g_ort_api->GetTensorTypeAndShape(output_tensor, &output_info));
-        size_t output_elements_count;
-        ORT_CHECK(g_ort_api->GetTensorShapeElementCount(output_info, &output_elements_count));
-        size_t required_output_bytes = output_elements_count * sizeof(float);
-        if (actual_output_len_bytes_out) *actual_output_len_bytes_out = required_output_bytes;
-        if (required_output_bytes <= output_buf_len_bytes) {
-            float* output_data_ptr_onnx = nullptr;
-            ORT_CHECK(g_ort_api->GetTensorMutableData(output_tensor, (void**)&output_data_ptr_onnx));
-            memcpy(output_data_to_enclave, output_data_ptr_onnx, required_output_bytes);
-            *host_return_value = OE_OK;
-        } else {
-            *host_return_value = OE_BUFFER_TOO_SMALL;
-        }
-        g_ort_api->ReleaseTensorTypeAndShapeInfo(output_info);
-        g_ort_api->ReleaseValue(output_tensor);
-        g_ort_api->ReleaseValue(attention_mask_tensor);
-        g_ort_api->ReleaseValue(input_ids_tensor);
-        g_ort_api->ReleaseMemoryInfo(memory_info);
-    } catch (const std::exception& e) {
-        *host_return_value = OE_FAILURE;
-    }
+    size_t* actual_output_len_bytes_out)
+{
+    if (!ocall_host_ret || !host_return_value)
+        return OE_INVALID_PARAMETER;
+
     *ocall_host_ret = OE_OK;
+    *host_return_value = OE_FAILURE;
+
+    auto it = g_sessions.find(host_session_handle);
+    if (it == g_sessions.end()) {
+        *host_return_value = OE_NOT_FOUND;
+        return OE_OK;
+    }
+
+    bert_ctx* ctx = it->second;
+    size_t num_tokens = input_len_bytes / sizeof(int64_t);
+    const int64_t* tokens64 = static_cast<const int64_t*>(input_data_from_enclave);
+    bert_tokens tokens;
+    tokens.reserve(num_tokens);
+    for (size_t i = 0; i < num_tokens; ++i) {
+        tokens.push_back(static_cast<bert_token>(tokens64[i]));
+    }
+
+    int n_embd = bert_n_embd(ctx);
+    std::vector<float> embeddings(n_embd);
+    bert_forward(ctx, tokens, embeddings.data(), 1);
+
+    size_t required = embeddings.size() * sizeof(float);
+    if (actual_output_len_bytes_out)
+        *actual_output_len_bytes_out = required;
+
+    if (required <= output_buf_len_bytes) {
+        memcpy(output_data_to_enclave, embeddings.data(), required);
+        *host_return_value = OE_OK;
+    } else {
+        *host_return_value = OE_BUFFER_TOO_SMALL;
+    }
     return OE_OK;
 }
 
 oe_result_t ocall_ggml_release_session(
     oe_result_t* ocall_host_ret,
     oe_result_t* host_return_value,
-    uint64_t host_session_handle) {
-    if (!ocall_host_ret || !host_return_value || !g_ort_api || host_session_handle == 0)
+    uint64_t host_session_handle)
+{
+    if (!ocall_host_ret || !host_return_value)
         return OE_INVALID_PARAMETER;
-    *ocall_host_ret = OE_FAILURE;
+
+    *ocall_host_ret = OE_OK;
     *host_return_value = OE_FAILURE;
-    auto it = g_host_ggml_sessions.find(host_session_handle);
-    if (it != g_host_ggml_sessions.end()) {
-        if (it->second) g_ort_api->ReleaseSession(it->second);
-        g_host_ggml_sessions.erase(it);
+
+    auto it = g_sessions.find(host_session_handle);
+    if (it != g_sessions.end()) {
+        bert_free(it->second);
+        g_sessions.erase(it);
         *host_return_value = OE_OK;
     } else {
         *host_return_value = OE_NOT_FOUND;
     }
-    *ocall_host_ret = OE_OK;
     return OE_OK;
 }
 
 int main(int argc, char* argv[]) {
-    oe_result_t oe_host_result;
     oe_enclave_t* enclave = nullptr;
     int host_app_ret_val = 1;
     uint64_t enclave_ml_session_handle = 0;
+
     if (argc < 3) {
         return 1;
     }
-    const std::string model_filepath = argv[1];
+    g_model_path = argv[1];
     const std::string enclave_filepath = argv[2];
     bool use_stdin = false;
     bool simulate = false;
@@ -191,25 +155,20 @@ int main(int argc, char* argv[]) {
         if (std::string(argv[i]) == "--use-stdin") use_stdin = true;
         else if (std::string(argv[i]) == "--simulate") simulate = true;
     }
-    g_ort_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
-    OrtThreadingOptions* threading_options = nullptr;
-    ORT_CHECK(g_ort_api->CreateThreadingOptions(&threading_options));
-    ORT_CHECK(g_ort_api->CreateEnvWithGlobalThreadPools(
-        ORT_LOGGING_LEVEL_WARNING, "host_app_ort_env",
-        threading_options, &g_host_ort_env));
-    g_ort_api->ReleaseThreadingOptions(threading_options);
+
     try {
         uint32_t enclave_flags = OE_ENCLAVE_FLAG_DEBUG;
         if (simulate) enclave_flags |= OE_ENCLAVE_FLAG_SIMULATE;
         OE_HOST_CHECK(oe_create_enclave_enclave(
             enclave_filepath.c_str(), OE_ENCLAVE_TYPE_AUTO,
             enclave_flags, nullptr, 0, &enclave), "oe_create_enclave_enclave");
-        std::vector<unsigned char> model_buffer = load_file_to_buffer(model_filepath);
+        std::vector<unsigned char> model_buffer = load_file_to_buffer(g_model_path);
         oe_result_t ecall_ret_status;
         OE_HOST_CHECK(initialize_enclave_ml_context(
             enclave, &ecall_ret_status, model_buffer.data(),
-            model_buffer.size(), &enclave_ml_session_handle), "initialize_enclave_ml_context (host call)");
-        OE_HOST_CHECK(ecall_ret_status, "initialize_enclave_ml_context (enclave execution)");
+            model_buffer.size(), &enclave_ml_session_handle), "initialize_enclave_ml_context");
+        OE_HOST_CHECK(ecall_ret_status, "initialize_enclave_ml_context (enclave)");
+
         std::vector<int64_t> input_tensor_values;
         if (use_stdin) {
             std::string line;
@@ -220,15 +179,16 @@ int main(int argc, char* argv[]) {
                 input_tensor_values.push_back(std::stoll(value_str));
             }
         }
+
         size_t input_data_byte_size = input_tensor_values.size() * sizeof(int64_t);
-        std::vector<float> output_tensor_values(20);
+        std::vector<float> output_tensor_values(768); // typical embedding size
         size_t output_buffer_byte_size = output_tensor_values.size() * sizeof(float);
         size_t actual_output_byte_size = 0;
         OE_HOST_CHECK(enclave_infer(
             enclave, &ecall_ret_status, enclave_ml_session_handle,
             input_tensor_values.data(), input_data_byte_size,
-            output_tensor_values.data(), output_buffer_byte_size, &actual_output_byte_size), "enclave_infer (host call)");
-        OE_HOST_CHECK(ecall_ret_status, "enclave_infer (enclave execution)");
+            output_tensor_values.data(), output_buffer_byte_size, &actual_output_byte_size), "enclave_infer");
+        OE_HOST_CHECK(ecall_ret_status, "enclave_infer (enclave)");
         size_t output_elements = actual_output_byte_size / sizeof(float);
         for (size_t i = 0; i < output_elements; ++i) {
             std::cout << output_tensor_values[i] << (i == output_elements - 1 ? "" : ", ");
@@ -236,10 +196,9 @@ int main(int argc, char* argv[]) {
         std::cout << std::endl;
         terminate_enclave_ml_context(enclave, &ecall_ret_status, enclave_ml_session_handle);
         host_app_ret_val = 0;
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         host_app_ret_val = 1;
     }
     if (enclave) oe_terminate_enclave(enclave);
-    if (g_host_ort_env) g_ort_api->ReleaseEnv(g_host_ort_env);
     return host_app_ret_val;
 }


### PR DESCRIPTION
## Summary
- remove stale onnxruntime entries
- introduce `AGENT.md` with contribution notes
- build bert.cpp as part of CMake configuration
- link host application against bert.cpp
- rework host implementation to use bert.cpp instead of ONNX Runtime

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684b133b7b34832a91f0799bd6f415b7