### PR TITLE
Handle progress lines in tokenizer output

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -137,7 +137,17 @@ func handleInference(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Tokenization failed", http.StatusInternalServerError)
 		return
 	}
-	tokenString := strings.TrimSpace(string(pyOutput))
+	// Split output by newline and take the last non-empty line.
+	lines := strings.Split(string(pyOutput), "\n")
+	tokenString := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			tokenString = line
+			break
+		}
+	}
+	tokenString = strings.TrimSpace(tokenString)
 
         // --- 2. Inference via C++ Worker ---
         resultString, err := runInference(tokenString)


### PR DESCRIPTION
## Summary
- handle multi-line tokenizer output in `backend/main.go`

## Testing
- `scripts/download_deps.sh`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_b_684f25d6e714832ab5217bcbdc728749